### PR TITLE
need this frontmatter for custom 404 to work

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 title: Page Not Found
+permalink: /404.html
 ---
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
You can test the current 404 page by going to https://thelehhman.com/texture/notfound

It will not show the custom 404, instead it shows GitHub Pages's 404:

![image](https://user-images.githubusercontent.com/48045453/73025807-29da2e80-3e28-11ea-8344-30484340fcde.png)

Adding one line to 404.html frontmatter made it work, at least on my page... Thanks.