### PR TITLE
Remove Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,6 @@ texture:
   disqus_shortname: games
 ```
 
-**Google Analytics**
-
-It can be enabled by specifying your analytics id under texture in `_config.yml`
-```yaml
-texture:
-  analytics_id: '< YOUR ID >'
-```
-
 **Excerpts**
 
 Excerpts can be enabled by adding the following line to your `_config.yml`

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,14 +1,3 @@
-{%- if site.texture.analytics_id -%}
-<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.texture.analytics_id }}"></script>
-<script>
-	window.dataLayer = window.dataLayer || [];
-	function gtag() { dataLayer.push(arguments); }
-	gtag('js', new Date());
-
-	gtag('config', '{{ site.texture.analytics_id }}');
-</script>
-{%- endif -%}
-
 {%- if site.texture.showPicker -%}
 <div id="texture-picker">
 	<div style="display:flex;justify-content: space-between">


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this theme? There are better alternatives if you _must_ keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/